### PR TITLE
ExtensionNormalizer checks data type is object

### DIFF
--- a/src/Extension/ExtensionNormalizer.php
+++ b/src/Extension/ExtensionNormalizer.php
@@ -33,7 +33,7 @@ class ExtensionNormalizer extends SerializerAwareNormalizer implements Normalize
 
     public function supportsNormalization($data, $format = null)
     {
-        return get_class($data) === 'Base\\Core\\Extension\\ExtensionCollection';
+        return is_object($data) && get_class($data) === 'Base\\Core\\Extension\\ExtensionCollection';
     }
 
     public function denormalize($data, $class, $format = null, array $context = [])


### PR DESCRIPTION
ExtensionNormalizer::supportsNormalization checks that an object has been
passed before calling get_class.

This fixes warnings raised on the NCT website where the ExtensionNormalizer
can be passed a null or empty array.